### PR TITLE
Bugfix: memoryleak of IsSolderprofileCSV() and loadSolderCsv() fixed

### DIFF
--- a/display-fw/utilities/src/ProfileParser.cpp
+++ b/display-fw/utilities/src/ProfileParser.cpp
@@ -54,6 +54,7 @@ bool IsSolderprofileCSV(std::string& filepath){
 	f_close(&file);
 
 	if(result != FR_OK || bytesRead != SOLDERPROFILE_FILEIDENTIFIER.size()){
+		delete[] buffer;
 		return false;
 	}
 
@@ -113,15 +114,18 @@ SolderProfile loadSolderCsv(std::string& filepath)
 	FIL file;
 	auto result = f_open(&file, filepath.c_str(), FA_READ);
 	if(result != FR_OK){
+		delete[] buffer;
 		return dummy;
 	}
 	unsigned int bytesRead = 0;
 	result = f_read(&file, buffer, filesize, &bytesRead);
 	if(result != FR_OK){
+		delete[] buffer;
 		return dummy;
 	}
 	result = f_close(&file);
 	if(result != FR_OK){
+		delete[] buffer;
 		return dummy;
 	}
 


### PR DESCRIPTION
Hi,
I hope you're doing well. I've solved some memory leak issues in the "ProfileParser.CPP" file.
In functions "IsSolderprofileCSV()" and "loadSolderCsv()", a buffer is allocated for file operations, but in some conditions, that buffer is not correctly deleted and causes stack problems.
Best regards